### PR TITLE
only allow single character insertion and backspace

### DIFF
--- a/components/client.tsx
+++ b/components/client.tsx
@@ -55,6 +55,9 @@ export default function Client({ color, txs, setTxs, client } : ClientProps) {
 
   function handleKeyUp(e: any) {
     const value = e.key
+    if (value.length !== 1 && value !== "Backspace") {
+      return
+    }
 
     let back
     if (e.target.value.length !== 0 && position === e.target.value.length) { // insertion at end


### PR DESCRIPTION
- only allow single character insertion (this fixes a bug where clients press Shift, Tab, Ctrl, etc.)

after
![CleanShot 2023-01-20 at 09 54 20](https://user-images.githubusercontent.com/1177031/213794113-c6549b89-3271-479f-8d88-939bae0f8dda.gif)

before
![CleanShot 2023-01-20 at 09 55 56](https://user-images.githubusercontent.com/1177031/213794139-0ff68021-8d7e-41cf-a76e-18d22783d02e.gif)
